### PR TITLE
Updated fetch call to avoid caching

### DIFF
--- a/src/components/foldingAtHome/FoldingCount.tsx
+++ b/src/components/foldingAtHome/FoldingCount.tsx
@@ -17,7 +17,7 @@ export default async function FoldingCount() {
     let p;
 
     try {
-        const call = await fetch(url);
+        const call = await fetch(url, {cache: "no-store"})
         const rijn = await call.json();
         users = rijn["users"];
         rank = rijn["rank"];


### PR DESCRIPTION
The fetch API call in the FoldingCount component has been updated to include a cache option set to "no-store". This change ensures that the data fetched is always fresh and not served from cache.
